### PR TITLE
Refactor dashboard for Laravel integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
-# SGPJ
-Think your self
+# SGPJ (Integração Laravel)
+
+Este repositório contém os recursos necessários para portar o dashboard SGPJ para uma aplicação Laravel existente.
+
+## Como usar
+
+1. Crie um novo projeto Laravel (`laravel new sgpj` ou `composer create-project laravel/laravel sgpj`).
+2. Copie os diretórios/arquivos deste repositório para o projeto Laravel, preservando a estrutura:
+   - `app/Http/Controllers`
+   - `config/sgpj.php`
+   - `public/css/app.css`
+   - `public/js/dashboard.js`
+   - `resources/views/...`
+   - `routes/web.php`
+   - `storage/app/sgpj/processos.json`
+3. Execute `composer install` (caso ainda não tenha feito) e gere a chave com `php artisan key:generate`.
+4. Garanta permissão de escrita em `storage/` e `bootstrap/cache/`.
+5. Inicie o servidor (`php artisan serve`).
+
+Após acessar `http://127.0.0.1:8000` você verá a nova tela de login. Credenciais válidas:
+
+- Usuário `tarcisio`, senha `123`
+- Usuário `lucas`, senha `123`
+
+A opção "Lembrar-me" cria um cookie persistente; desative-a para manter a sessão apenas no navegador atual.
+
+## Arquitetura
+
+- `AuthController` valida as credenciais configuradas em `config/sgpj.php`, cria a sessão e gerencia o cookie de "lembrar".
+- `DashboardController` garante que apenas usuários autenticados acessem o painel e injeta dados do usuário na view.
+- `ProcessoController` devolve o JSON de processos localizado em `storage/app/sgpj/processos.json`.
+- `resources/views/auth/login.blade.php` define a tela de login moderna, mantendo a estética original.
+- `resources/views/dashboard/index.blade.php` renderiza o kanban/lista, menu lateral, botão de recarregar e modo escuro.
+- `public/js/dashboard.js` centraliza o comportamento do front-end (filtros, alternância de visualização, tema, drawer e logout).
+- `public/css/app.css` contém a paleta, layouts responsivos e estilos do modo escuro.
+
+## Endpoints
+
+- `GET /` — painel (requer autenticação)
+- `GET /login` — formulário de login
+- `POST /login` — autenticação
+- `POST /logout` — encerra a sessão
+- `GET /processos` — retorna o JSON consumido pelo front-end
+
+## Observações
+
+- Adapte `config/sgpj.php` para incluir novos usuários ou alterar o local do arquivo de dados.
+- O botão de recarregar força `window.location.reload()`, garantindo dados atualizados.
+- A preferência de tema escuro é salva em `localStorage` (`sgpj-dashboard-tema`).
+
+Este pacote foi pensado para ser aplicado sobre uma base Laravel limpa; ele não inclui o framework completo por motivos de tamanho/licenciamento.

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cookie;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\View\View;
+
+class AuthController extends Controller
+{
+    /**
+     * Display the login form.
+     */
+    public function showLoginForm(Request $request): View|RedirectResponse
+    {
+        if ($request->session()->has('sgpj_user')) {
+            return redirect()->route('dashboard');
+        }
+
+        $remembered = $request->cookie(Config::get('sgpj.remember_cookie'));
+        $users = Config::get('sgpj.users', []);
+
+        if ($remembered && isset($users[$remembered])) {
+            $this->storeUserInSession($request, $remembered, $users[$remembered]['name'] ?? $remembered);
+
+            return redirect()->route('dashboard');
+        }
+
+        return view('auth.login');
+    }
+
+    /**
+     * Handle the incoming login request.
+     */
+    public function login(Request $request): RedirectResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'username' => ['required', 'string'],
+            'password' => ['required', 'string'],
+            'remember' => ['nullable', 'boolean'],
+        ]);
+
+        if ($validator->fails()) {
+            return back()->withErrors($validator)->withInput($request->except('password'));
+        }
+
+        $username = strtolower($validator->validated()['username']);
+        $password = $validator->validated()['password'];
+
+        $users = Config::get('sgpj.users', []);
+        $userData = $users[$username] ?? null;
+
+        if (!$userData || !hash_equals($userData['password'] ?? '', $password)) {
+            return back()
+                ->withErrors(['username' => 'Usuário ou senha inválidos.'])
+                ->withInput($request->except('password'));
+        }
+
+        $displayName = $userData['name'] ?? ucfirst($username);
+        $this->storeUserInSession($request, $username, $displayName);
+
+        $response = redirect()->route('dashboard');
+
+        if ($request->boolean('remember')) {
+            $response->withCookie(cookie()->forever(Config::get('sgpj.remember_cookie'), $username));
+        } else {
+            $response->withoutCookie(Config::get('sgpj.remember_cookie'));
+        }
+
+        return $response;
+    }
+
+    /**
+     * Destroy the authenticated session.
+     */
+    public function logout(Request $request): RedirectResponse
+    {
+        $request->session()->forget(['sgpj_user', 'sgpj_username']);
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect()->route('login')->withoutCookie(Config::get('sgpj.remember_cookie'));
+    }
+
+    private function storeUserInSession(Request $request, string $username, string $displayName): void
+    {
+        $request->session()->put('sgpj_username', $username);
+        $request->session()->put('sgpj_user', $displayName);
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
+use Illuminate\View\View;
+
+class DashboardController extends Controller
+{
+    public function index(Request $request): View|RedirectResponse
+    {
+        $user = $request->session()->get('sgpj_user');
+
+        if (!$user) {
+            $remembered = $request->cookie(Config::get('sgpj.remember_cookie'));
+            $users = Config::get('sgpj.users', []);
+
+            if ($remembered && isset($users[$remembered])) {
+                $displayName = $users[$remembered]['name'] ?? ucfirst($remembered);
+                $request->session()->put('sgpj_username', $remembered);
+                $request->session()->put('sgpj_user', $displayName);
+                $user = $displayName;
+            } else {
+                return redirect()->route('login');
+            }
+        }
+
+        return view('dashboard.index', [
+            'usuario' => $user,
+        ]);
+    }
+}

--- a/app/Http/Controllers/ProcessoController.php
+++ b/app/Http/Controllers/ProcessoController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+
+class ProcessoController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        $storagePath = Config::get('sgpj.processos_storage');
+        $conteudo = [];
+
+        if ($storagePath && Storage::exists($storagePath)) {
+            try {
+                $conteudo = json_decode(Storage::get($storagePath), true, 512, JSON_THROW_ON_ERROR);
+            } catch (\JsonException) {
+                $conteudo = [];
+            }
+        }
+
+        if (!is_array($conteudo)) {
+            $conteudo = [];
+        }
+
+        return response()->json($conteudo);
+    }
+}

--- a/config/sgpj.php
+++ b/config/sgpj.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    'remember_cookie' => 'sgpj_remember_user',
+
+    'users' => [
+        'tarcisio' => [
+            'name' => 'Tarcisio',
+            'password' => '123',
+        ],
+        'lucas' => [
+            'name' => 'Lucas',
+            'password' => '123',
+        ],
+    ],
+
+    'processos_storage' => 'sgpj/processos.json',
+];

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,0 +1,1311 @@
+:root {
+  color-scheme: light;
+  --font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --color-surface: #ffffff;
+  --color-surface-alt: #f8fafc;
+  --color-border: #e2e8f0;
+  --color-border-strong: #cbd5f5;
+  --color-text: #1e293b;
+  --color-text-muted: #64748b;
+  --color-primary: #1da1f2;
+  --color-primary-strong: #0f75c3;
+  --color-accent: #10b981;
+  --color-danger: #f87171;
+  --shadow-soft: 0 8px 24px rgba(15, 23, 42, 0.08);
+  --radius-lg: 20px;
+  --radius-md: 14px;
+  --radius-sm: 10px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font-family);
+  background: linear-gradient(180deg, #f0f4ff 0%, #f8fafc 100%);
+  color: var(--color-text);
+}
+
+body.drawer-open {
+  overflow: hidden;
+}
+
+body.theme-dark {
+  color-scheme: dark;
+  --color-surface: #111827;
+  --color-surface-alt: #0f172a;
+  --color-border: #1f2937;
+  --color-border-strong: #334155;
+  --color-text: #e2e8f0;
+  --color-text-muted: #94a3b8;
+  --color-primary: #38bdf8;
+  --color-primary-strong: #0ea5e9;
+  --color-accent: #22d3ee;
+  --color-danger: #fca5a5;
+  --shadow-soft: 0 20px 44px rgba(2, 6, 23, 0.6);
+  background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.16), transparent 52%),
+    radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.12), transparent 48%),
+    linear-gradient(180deg, #020617 0%, #0f172a 100%);
+  color: var(--color-text);
+}
+
+body.theme-dark .login-screen {
+  background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.24), transparent 55%),
+    radial-gradient(circle at bottom left, rgba(14, 165, 233, 0.2), transparent 45%),
+    linear-gradient(180deg, #020617 0%, #0b1526 100%);
+}
+
+body.theme-dark .login-card {
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(51, 65, 85, 0.85);
+  box-shadow: 0 32px 55px rgba(2, 6, 23, 0.65);
+}
+
+body.theme-dark .login-card::before {
+  background: linear-gradient(145deg, rgba(56, 189, 248, 0.12), rgba(30, 64, 175, 0.08));
+}
+
+body.theme-dark .login-card::after {
+  background: radial-gradient(circle, rgba(30, 58, 138, 0.32), rgba(2, 6, 23, 0));
+}
+
+body.theme-dark .login-field input {
+  background: rgba(17, 24, 39, 0.9);
+  border: 1px solid rgba(71, 85, 105, 0.7);
+  color: var(--color-text);
+}
+
+body.theme-dark .login-field input:focus {
+  border-color: rgba(14, 165, 233, 0.8);
+  box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.32);
+}
+
+body.theme-dark .login-remember span,
+body.theme-dark .login-hint {
+  color: var(--color-text-muted);
+}
+
+body.theme-dark .login-submit {
+  box-shadow: 0 20px 38px rgba(14, 165, 233, 0.35);
+}
+
+body.theme-dark .login-submit:hover {
+  box-shadow: 0 26px 46px rgba(14, 165, 233, 0.4);
+}
+
+body.theme-dark .app-header,
+body.theme-dark .board-toolbar,
+body.theme-dark .filters,
+body.theme-dark .board-list {
+  background: var(--color-surface-alt);
+  border-color: var(--color-border-strong);
+  box-shadow: 0 24px 46px rgba(2, 6, 23, 0.55);
+}
+
+body.theme-dark .icon-button {
+  background: rgba(30, 41, 59, 0.82);
+  border-color: rgba(71, 85, 105, 0.75);
+  color: var(--color-text);
+}
+
+body.theme-dark .icon-button:hover {
+  background: rgba(56, 189, 248, 0.18);
+  border-color: rgba(56, 189, 248, 0.4);
+}
+
+body.theme-dark .icon-button.is-active {
+  box-shadow: 0 16px 30px rgba(14, 165, 233, 0.4);
+}
+
+body.theme-dark .header-chip {
+  background: rgba(56, 189, 248, 0.16);
+  color: var(--color-primary);
+}
+
+body.theme-dark .header-user {
+  background: rgba(34, 197, 94, 0.22);
+  color: #bbf7d0;
+}
+
+body.theme-dark select,
+body.theme-dark input[type='search'] {
+  background: rgba(17, 24, 39, 0.9);
+  border: 1px solid rgba(71, 85, 105, 0.7);
+  color: var(--color-text);
+}
+
+body.theme-dark select:focus,
+body.theme-dark input[type='search']:focus {
+  border-color: rgba(14, 165, 233, 0.8);
+  box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.3);
+}
+
+body.theme-dark .ghost-button {
+  color: var(--color-primary);
+}
+
+body.theme-dark .ghost-button:hover {
+  background: rgba(56, 189, 248, 0.16);
+}
+
+body.theme-dark .board-column {
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(51, 65, 85, 0.9);
+  box-shadow: 0 20px 42px rgba(2, 6, 23, 0.55);
+}
+
+body.theme-dark .column-dot {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.45), rgba(16, 185, 129, 0.45));
+}
+
+body.theme-dark .column-count {
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--color-text-muted);
+}
+
+body.theme-dark .deal-card {
+  background: rgba(17, 24, 39, 0.96);
+  border: 1px solid rgba(71, 85, 105, 0.55);
+  box-shadow: 0 24px 48px rgba(2, 6, 23, 0.6);
+}
+
+body.theme-dark .deal-card__status {
+  background: rgba(16, 185, 129, 0.2);
+  color: #4ade80;
+}
+
+body.theme-dark .card-pill {
+  background: rgba(56, 189, 248, 0.2);
+  color: var(--color-primary);
+}
+
+body.theme-dark .card-actions button {
+  color: var(--color-text-muted);
+}
+
+body.theme-dark .card-actions button:hover {
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--color-text);
+}
+
+body.theme-dark .empty-column {
+  background: rgba(17, 24, 39, 0.65);
+  border: 1px dashed rgba(100, 116, 139, 0.45);
+  color: var(--color-text-muted);
+}
+
+body.theme-dark .board-list__table th,
+body.theme-dark .board-list__table td {
+  border-bottom: 1px solid rgba(51, 65, 85, 0.8);
+}
+
+body.theme-dark .board-list__table th {
+  background: rgba(30, 41, 59, 0.6);
+  color: var(--color-text-muted);
+}
+
+body.theme-dark .board-list__table tbody tr:hover {
+  background: rgba(30, 41, 59, 0.55);
+}
+
+body.theme-dark .board-list__empty {
+  background: rgba(17, 24, 39, 0.7);
+  border: 1px dashed rgba(100, 116, 139, 0.45);
+  color: var(--color-text-muted);
+}
+
+body.theme-dark .status-badge {
+  background: rgba(56, 189, 248, 0.22);
+  color: var(--color-primary);
+}
+
+body.theme-dark .help-button {
+  background: linear-gradient(135deg, #3730a3, #6d28d9);
+  box-shadow: 0 24px 40px rgba(76, 29, 149, 0.45);
+}
+
+body.theme-dark .drawer-overlay {
+  background: rgba(2, 6, 23, 0.7);
+}
+
+body.theme-dark .side-drawer {
+  background: rgba(15, 23, 42, 0.96);
+  border-left: 1px solid rgba(51, 65, 85, 0.85);
+  box-shadow: -24px 0 48px rgba(2, 6, 23, 0.6);
+}
+
+body.theme-dark .side-drawer__title {
+  color: var(--color-text);
+}
+
+body.theme-dark .side-drawer__link {
+  background: rgba(17, 24, 39, 0.9);
+  color: var(--color-text);
+}
+
+body.theme-dark .side-drawer__link:hover,
+body.theme-dark .side-drawer__link:focus-visible {
+  background: rgba(56, 189, 248, 0.18);
+  box-shadow: 0 14px 26px rgba(2, 6, 23, 0.55);
+}
+
+body.theme-dark .side-drawer__settings {
+  border-top: 1px solid rgba(51, 65, 85, 0.8);
+}
+
+body.theme-dark .settings-toggle__description {
+  color: var(--color-text-muted);
+}
+
+body.theme-dark .switch {
+  background: rgba(71, 85, 105, 0.7);
+  box-shadow: inset 0 0 0 1px rgba(100, 116, 139, 0.6);
+}
+
+body.theme-dark .switch__thumb {
+  background: #020617;
+  box-shadow: 0 6px 12px rgba(2, 6, 23, 0.5);
+}
+
+body.theme-dark .switch__input:focus-visible + .switch {
+  box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.3), inset 0 0 0 1px rgba(100, 116, 139, 0.6);
+}
+
+body.theme-dark .switch__input:checked + .switch .switch__thumb {
+  background: #0f172a;
+  box-shadow: 0 6px 14px rgba(14, 165, 233, 0.4);
+}
+
+.login-screen {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: clamp(2rem, 6vw, 4rem);
+  background: radial-gradient(circle at top right, rgba(29, 161, 242, 0.18), transparent 55%),
+    radial-gradient(circle at bottom left, rgba(16, 185, 129, 0.18), transparent 45%),
+    linear-gradient(180deg, #f0f4ff 0%, #f8fafc 100%);
+  transition: opacity 0.4s ease, visibility 0.4s ease;
+  z-index: 10;
+}
+
+.login-screen.is-hidden {
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+}
+
+.login-card {
+  width: min(420px, 100%);
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  padding: clamp(2rem, 4vw, 2.5rem);
+  box-shadow: 0 28px 45px rgba(15, 23, 42, 0.18);
+  display: grid;
+  gap: 1.75rem;
+  position: relative;
+  overflow: visible;
+}
+
+.login-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(145deg, rgba(29, 161, 242, 0.08), rgba(15, 118, 210, 0.04));
+  pointer-events: none;
+}
+
+.login-card::after {
+  content: '';
+  position: absolute;
+  inset: auto;
+  top: 60%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 120%;
+  height: 60%;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(15, 118, 210, 0.18), rgba(15, 23, 42, 0));
+  filter: blur(40px);
+  z-index: 0;
+  pointer-events: none;
+}
+
+.login-card__header {
+  display: grid;
+  gap: 0.6rem;
+  position: relative;
+  z-index: 1;
+}
+
+.login-brand {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.9rem;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 1.25rem;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
+  color: #fff;
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.18);
+}
+
+.login-title {
+  margin: 0;
+  font-size: clamp(1.55rem, 2.5vw, 1.9rem);
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.login-subtitle {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.login-form {
+  display: grid;
+  gap: 1.15rem;
+  position: relative;
+  z-index: 1;
+}
+
+.login-field {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.login-field input {
+  width: 100%;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  padding: 0.75rem 0.9rem;
+  font: inherit;
+  color: var(--color-text);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.login-field input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(29, 161, 242, 0.25);
+  transform: translateY(-1px);
+}
+
+.login-remember {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.login-remember input {
+  width: 1.05rem;
+  height: 1.05rem;
+  margin: 0;
+  accent-color: var(--color-primary);
+  cursor: pointer;
+  border-radius: 0.35rem;
+}
+
+.login-remember span {
+  cursor: pointer;
+}
+
+.login-submit {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 0.9rem 1.2rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
+  color: #fff;
+  box-shadow: 0 18px 32px rgba(29, 161, 242, 0.32);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.login-submit:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 36px rgba(29, 161, 242, 0.32);
+  filter: brightness(1.02);
+}
+
+.login-hint {
+  margin: 0;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+}
+
+.login-error {
+  margin: 0;
+  min-height: 1.25rem;
+  color: var(--color-danger);
+  font-weight: 600;
+  text-align: center;
+}
+
+.drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.32);
+  backdrop-filter: blur(2px);
+  transition: opacity 0.3s ease;
+  opacity: 0;
+  pointer-events: none;
+  z-index: 11;
+}
+
+.drawer-overlay:not([hidden]) {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.side-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: min(320px, 85vw);
+  background: var(--color-surface);
+  border-left: 1px solid rgba(226, 232, 240, 0.9);
+  box-shadow: -20px 0 45px rgba(15, 23, 42, 0.2);
+  transform: translateX(105%);
+  transition: transform 0.3s ease;
+  z-index: 12;
+  display: flex;
+  flex-direction: column;
+  padding: 1.75rem 1.5rem;
+  gap: 1.5rem;
+}
+
+.side-drawer.is-open {
+  transform: translateX(0);
+}
+
+.side-drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.side-drawer__title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.side-drawer__close {
+  padding: 0.4rem 0.65rem;
+}
+
+.side-drawer__nav {
+  flex: 1;
+}
+
+.side-drawer__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.side-drawer__link {
+  width: 100%;
+  appearance: none;
+  border: none;
+  background: rgba(248, 250, 252, 0.9);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 1rem;
+  text-align: left;
+  font: inherit;
+  font-weight: 600;
+  color: var(--color-text);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.side-drawer__link:hover,
+.side-drawer__link:focus-visible {
+  outline: none;
+  transform: translateX(-4px);
+  background: rgba(29, 161, 242, 0.12);
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.08);
+}
+
+.side-drawer__settings {
+  border-top: 1px solid var(--color-border);
+  padding-top: 1.25rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.side-drawer__settings[hidden] {
+  display: none;
+}
+
+.side-drawer__settings.is-visible {
+  animation: drawerSettingsFade 0.25s ease;
+}
+
+.side-drawer__settings-title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+
+.settings-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.settings-toggle__text {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.settings-toggle__title {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.settings-toggle__description {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.settings-toggle__control {
+  position: relative;
+  width: 3.1rem;
+  height: 1.65rem;
+  flex-shrink: 0;
+}
+
+.switch__input {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.switch {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.45);
+  display: flex;
+  align-items: center;
+  padding: 0 0.25rem;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+  pointer-events: none;
+}
+
+.switch__thumb {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.18);
+  transform: translateX(0);
+  transition: transform 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.switch__input:focus-visible + .switch {
+  box-shadow: 0 0 0 3px rgba(29, 161, 242, 0.35), inset 0 0 0 1px rgba(148, 163, 184, 0.45);
+}
+
+.switch__input:checked + .switch {
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
+  box-shadow: 0 12px 22px rgba(29, 161, 242, 0.3);
+}
+
+.switch__input:checked + .switch .switch__thumb {
+  transform: translateX(1.35rem);
+  background: #fff;
+  box-shadow: 0 4px 12px rgba(29, 161, 242, 0.24);
+}
+
+@keyframes drawerSettingsFade {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.header-user {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  background: rgba(16, 185, 129, 0.14);
+  color: #0b6b50;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.header-user[hidden] {
+  display: none;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem clamp(1.5rem, 3vw, 3rem);
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+}
+
+.app-shell.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.app-shell[hidden] {
+  display: none;
+}
+
+.app-header,
+.board-toolbar,
+.filters {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1rem 1.25rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.product-logo {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: #fff;
+  font-size: 1.5rem;
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.2);
+}
+
+.header-title-group {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.header-eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  font-weight: 600;
+}
+
+.header-title {
+  margin: 0;
+  font-size: clamp(1.35rem, 2.5vw, 1.65rem);
+  font-weight: 700;
+}
+
+.header-subtitle {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.header-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: rgba(29, 161, 242, 0.12);
+  color: var(--color-primary-strong);
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.icon-button {
+  appearance: none;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+  border-radius: 999px;
+  padding: 0.55rem 0.7rem;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.icon-button:hover {
+  background-color: #eef4ff;
+  border-color: var(--color-border-strong);
+}
+
+.icon-button.is-active {
+  background: var(--color-primary);
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 10px 18px rgba(29, 161, 242, 0.3);
+}
+
+.icon-button--reload {
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 12px 22px rgba(29, 161, 242, 0.28);
+}
+
+.icon-button--reload:hover {
+  background: linear-gradient(135deg, var(--color-primary-strong), var(--color-primary));
+  box-shadow: 0 18px 30px rgba(29, 161, 242, 0.28);
+}
+
+.primary-button {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.5rem;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 22px rgba(29, 161, 242, 0.28);
+}
+
+.primary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 30px rgba(29, 161, 242, 0.28);
+}
+
+.board-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.toolbar-tabs {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.tab {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  font-weight: 600;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.tab:hover {
+  color: var(--color-text);
+  background: rgba(15, 23, 42, 0.04);
+}
+
+.tab.is-active {
+  background: rgba(29, 161, 242, 0.15);
+  color: var(--color-primary-strong);
+}
+
+.filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem 1.25rem;
+  align-items: end;
+}
+
+.filter {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.filter-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+}
+
+select,
+input[type='search'] {
+  appearance: none;
+  width: 100%;
+  padding: 0.65rem 0.8rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  font: inherit;
+  color: var(--color-text);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+select:focus,
+input[type='search']:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(29, 161, 242, 0.25);
+}
+
+.filter--search {
+  grid-column: span 2;
+}
+
+.ghost-button {
+  align-self: center;
+  justify-self: end;
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--color-primary-strong);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  transition: background-color 0.2s ease;
+}
+
+.ghost-button:hover {
+  background: rgba(29, 161, 242, 0.08);
+}
+
+.board {
+  flex: 1;
+  display: flex;
+  gap: 1.5rem;
+  overflow-x: auto;
+  padding-bottom: 1.5rem;
+}
+
+.board::-webkit-scrollbar {
+  height: 10px;
+}
+
+.board::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.board-list {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-soft);
+  overflow-x: auto;
+}
+
+.board-list__table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
+
+.board-list__table th,
+.board-list__table td {
+  padding: 0.75rem 0.65rem;
+  text-align: left;
+  font-size: 0.85rem;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.6);
+  color: var(--color-text);
+}
+
+.board-list__table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.board-list__table th:nth-child(1),
+.board-list__table td:nth-child(1) {
+  width: 80px;
+}
+
+.board-list__table th:nth-child(5),
+.board-list__table td:nth-child(5) {
+  text-align: right;
+}
+
+.board-list__table th:nth-child(6),
+.board-list__table td:nth-child(6) {
+  text-align: center;
+}
+
+.board-list__table th {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  background: rgba(15, 23, 42, 0.04);
+}
+
+.board-list__table tbody tr:hover {
+  background: rgba(15, 23, 42, 0.04);
+}
+
+.board-list__empty {
+  min-height: 160px;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  border-radius: var(--radius-md);
+  background: rgba(248, 250, 252, 0.7);
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(29, 161, 242, 0.12);
+  color: var(--color-primary-strong);
+  font-weight: 600;
+  font-size: 0.75rem;
+}
+
+.board::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.4);
+  border-radius: 999px;
+}
+
+.board-column {
+  flex: 0 0 310px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(226, 232, 240, 0.7);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem 1rem;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 16rem);
+}
+
+.column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.column-title {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-weight: 600;
+}
+
+.column-title h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.column-dot {
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(29, 161, 242, 0.35), rgba(16, 185, 129, 0.4));
+}
+
+.column-count {
+  background: rgba(15, 23, 42, 0.06);
+  border-radius: 999px;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.column-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.column-cards::-webkit-scrollbar {
+  width: 6px;
+}
+
+.column-cards::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.3);
+  border-radius: 999px;
+}
+
+.deal-card {
+  background: #fff;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  padding: 1rem 1.1rem;
+  display: grid;
+  gap: 0.75rem;
+  box-shadow: 0 14px 25px rgba(15, 23, 42, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.deal-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 30px rgba(15, 23, 42, 0.12);
+}
+
+.deal-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.deal-card__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(16, 185, 129, 0.15);
+  color: rgba(14, 159, 110, 1);
+}
+
+.deal-card__value {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.deal-card__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.deal-card__meta {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.deal-card__meta span {
+  display: block;
+}
+
+.deal-card__meta strong {
+  color: var(--color-text);
+}
+
+.deal-card__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.card-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--color-primary-strong);
+  font-weight: 600;
+}
+
+.card-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.card-actions button {
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 999px;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.card-actions button:hover {
+  background-color: rgba(15, 23, 42, 0.06);
+  color: var(--color-text);
+}
+
+.empty-column {
+  display: grid;
+  place-items: center;
+  text-align: center;
+  min-height: 120px;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  background: rgba(248, 250, 252, 0.7);
+}
+
+.help-button {
+  position: fixed;
+  right: clamp(1rem, 4vw, 2rem);
+  bottom: clamp(1rem, 4vw, 2rem);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.65rem 1.05rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 16px 28px rgba(99, 102, 241, 0.28);
+}
+
+.help-button span:first-child {
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.2);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+}
+
+@media (max-width: 980px) {
+  .app-header,
+  .board-toolbar,
+  .filters {
+    padding: 1rem;
+  }
+
+  .header-left {
+    flex-wrap: wrap;
+  }
+
+  .header-chip {
+    margin-left: auto;
+  }
+
+  .board {
+    gap: 1rem;
+  }
+
+  .board-column {
+    flex-basis: 280px;
+  }
+}
+
+@media (max-width: 720px) {
+  .app-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .header-actions {
+    justify-content: flex-end;
+  }
+
+  .filters {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+
+  .filter--search {
+    grid-column: span 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -1,0 +1,822 @@
+(function () {
+  const columns = [
+    { id: 'em-atendimento', label: 'Em atendimento' },
+    { id: 'orcamento-proposta', label: 'Orçamento enviado' },
+    { id: 'orcamento-aprovado', label: 'Orçamento aprovado' },
+    { id: 'aguardando', label: 'Aguardando retorno' },
+    { id: 'finalizados', label: 'Finalizados' }
+  ];
+
+  const moedaFormatter = new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL'
+  });
+
+  const THEME_STORAGE_KEY = 'sgpj-dashboard-tema';
+
+  let processos = [];
+  let filtrosAtivos = {
+    status: 'all',
+    search: '',
+    sort: 'recent'
+  };
+
+  let columnElements = new Map();
+  let statusFilter;
+  let sortFilter;
+  let searchInput;
+  let clearFiltersButton;
+  let totalProcessosChip;
+  let drawerToggleButton;
+  let drawerOverlay;
+  let sideDrawer;
+  let drawerCloseButton;
+  let drawerActionButtons = [];
+  let settingsPanel;
+  let settingsButton;
+  let themeToggle;
+  let appInitialized = false;
+  let viewToggleButtons = [];
+  let reloadButton;
+  let boardView;
+  let listView;
+  let currentView = 'board';
+  let temaAtual = 'light';
+  let processosEndpoint = '/processos';
+  let homeUrl = '/';
+  let logoutForm;
+
+  document.addEventListener('DOMContentLoaded', prepararInterface);
+
+  function prepararInterface() {
+    drawerToggleButton = document.querySelector('[data-drawer-toggle]');
+    drawerOverlay = document.getElementById('drawer-overlay');
+    sideDrawer = document.getElementById('side-drawer');
+    drawerCloseButton = document.getElementById('drawer-close');
+    drawerActionButtons = Array.from(document.querySelectorAll('[data-drawer-action]'));
+    settingsPanel = document.getElementById('drawer-settings');
+    settingsButton = document.querySelector('[data-drawer-action="settings"]');
+    themeToggle = document.getElementById('theme-toggle');
+    viewToggleButtons = Array.from(document.querySelectorAll('[data-view-toggle]'));
+    reloadButton = document.querySelector('[data-reload]');
+    boardView = document.getElementById('board-view');
+    listView = document.getElementById('board-list');
+    logoutForm = document.getElementById('logout-form');
+
+    const processosMeta = document.querySelector('meta[name="processos-endpoint"]');
+    if (processosMeta && processosMeta.getAttribute('content')) {
+      processosEndpoint = processosMeta.getAttribute('content');
+    }
+
+    const homeMeta = document.querySelector('meta[name="home-url"]');
+    if (homeMeta && homeMeta.getAttribute('content')) {
+      homeUrl = homeMeta.getAttribute('content');
+    }
+
+    aplicarTema(recuperarTemaPreferido() || 'light');
+
+    if (themeToggle) {
+      themeToggle.checked = temaAtual === 'dark';
+      themeToggle.addEventListener('change', function () {
+        const novoTema = themeToggle.checked ? 'dark' : 'light';
+        aplicarTema(novoTema);
+        salvarTemaPreferido(novoTema);
+      });
+    }
+
+    configurarMenuLateral();
+    inicializarAplicacao();
+  }
+
+  function salvarTemaPreferido(tema) {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, tema === 'dark' ? 'dark' : 'light');
+    } catch (erro) {
+      console.warn('Não foi possível salvar o tema preferido.', erro);
+    }
+  }
+
+  function recuperarTemaPreferido() {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+    try {
+      return window.localStorage.getItem(THEME_STORAGE_KEY);
+    } catch (erro) {
+      return null;
+    }
+  }
+
+  function inicializarAplicacao() {
+    if (appInitialized) {
+      return;
+    }
+
+    columnElements = new Map(
+      Array.from(document.querySelectorAll('.board-column')).map(function (column) {
+        return [column.getAttribute('data-column'), column];
+      })
+    );
+
+    statusFilter = document.getElementById('status-filter');
+    sortFilter = document.getElementById('sort-filter');
+    searchInput = document.getElementById('search-input');
+    clearFiltersButton = document.getElementById('clear-filters');
+    totalProcessosChip = document.getElementById('total-processos');
+    boardView = boardView || document.getElementById('board-view');
+    listView = listView || document.getElementById('board-list');
+
+    carregarProcessos();
+    registrarEventos();
+    appInitialized = true;
+    alternarVisualizacao(currentView);
+  }
+
+  function configurarMenuLateral() {
+    if (drawerToggleButton) {
+      drawerToggleButton.addEventListener('click', function () {
+        if (sideDrawer && sideDrawer.classList.contains('is-open')) {
+          fecharMenuLateral();
+        } else {
+          abrirMenuLateral();
+        }
+      });
+    }
+
+    if (drawerOverlay) {
+      drawerOverlay.addEventListener('click', fecharMenuLateral);
+    }
+
+    if (drawerCloseButton) {
+      drawerCloseButton.addEventListener('click', fecharMenuLateral);
+    }
+
+    drawerActionButtons.forEach(function (botao) {
+      botao.addEventListener('click', function () {
+        const acao = botao.getAttribute('data-drawer-action');
+        tratarAcaoMenu(acao);
+      });
+    });
+
+    document.addEventListener('keydown', function (event) {
+      if (event.key === 'Escape' && sideDrawer && sideDrawer.classList.contains('is-open')) {
+        fecharMenuLateral();
+      }
+    });
+  }
+
+  function abrirMenuLateral() {
+    if (!sideDrawer) {
+      return;
+    }
+
+    ocultarConfiguracoes();
+
+    sideDrawer.classList.add('is-open');
+    sideDrawer.setAttribute('aria-hidden', 'false');
+
+    if (drawerOverlay) {
+      drawerOverlay.hidden = false;
+    }
+
+    if (drawerToggleButton) {
+      drawerToggleButton.setAttribute('aria-expanded', 'true');
+    }
+
+    document.body.classList.add('drawer-open');
+
+    const primeiroLink = sideDrawer.querySelector('.side-drawer__link');
+    if (primeiroLink) {
+      primeiroLink.focus();
+    }
+  }
+
+  function fecharMenuLateral() {
+    if (!sideDrawer) {
+      return;
+    }
+
+    sideDrawer.classList.remove('is-open');
+    sideDrawer.setAttribute('aria-hidden', 'true');
+
+    if (drawerOverlay) {
+      drawerOverlay.hidden = true;
+    }
+
+    if (drawerToggleButton) {
+      drawerToggleButton.setAttribute('aria-expanded', 'false');
+      drawerToggleButton.focus();
+    }
+
+    document.body.classList.remove('drawer-open');
+    ocultarConfiguracoes();
+  }
+
+  function tratarAcaoMenu(acao) {
+    switch (acao) {
+      case 'home':
+        fecharMenuLateral();
+        if (typeof window !== 'undefined' && homeUrl) {
+          window.location.assign(homeUrl);
+        }
+        break;
+      case 'logout':
+        fecharMenuLateral();
+        encerrarSessao();
+        break;
+      case 'settings':
+        alternarConfiguracoes();
+        break;
+      default:
+        fecharMenuLateral();
+        break;
+    }
+  }
+
+  function alternarConfiguracoes() {
+    if (!settingsPanel) {
+      return;
+    }
+
+    if (settingsPanel.hasAttribute('hidden')) {
+      mostrarConfiguracoes();
+    } else {
+      ocultarConfiguracoes();
+    }
+  }
+
+  function mostrarConfiguracoes() {
+    if (!settingsPanel) {
+      return;
+    }
+
+    settingsPanel.removeAttribute('hidden');
+    settingsPanel.setAttribute('aria-hidden', 'false');
+    settingsPanel.classList.add('is-visible');
+
+    if (settingsButton) {
+      settingsButton.setAttribute('aria-expanded', 'true');
+    }
+
+    if (themeToggle) {
+      themeToggle.focus();
+    }
+  }
+
+  function ocultarConfiguracoes() {
+    if (!settingsPanel) {
+      return;
+    }
+
+    settingsPanel.setAttribute('hidden', '');
+    settingsPanel.setAttribute('aria-hidden', 'true');
+    settingsPanel.classList.remove('is-visible');
+
+    if (settingsButton) {
+      settingsButton.setAttribute('aria-expanded', 'false');
+    }
+  }
+
+  function encerrarSessao() {
+    if (logoutForm) {
+      logoutForm.submit();
+    }
+  }
+
+  function aplicarTema(tema) {
+    temaAtual = tema === 'dark' ? 'dark' : 'light';
+
+    const root = typeof document !== 'undefined' ? document.documentElement : null;
+    if (root) {
+      root.style.colorScheme = temaAtual === 'dark' ? 'dark' : 'light';
+    }
+
+    if (typeof document !== 'undefined' && document.body) {
+      document.body.classList.toggle('theme-dark', temaAtual === 'dark');
+    }
+
+    if (themeToggle) {
+      const ativo = temaAtual === 'dark';
+      themeToggle.checked = ativo;
+      themeToggle.setAttribute('aria-checked', ativo ? 'true' : 'false');
+    }
+  }
+
+  function carregarProcessos() {
+    fetch(processosEndpoint, { cache: 'no-store', headers: { Accept: 'application/json' } })
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error('Não foi possível carregar os processos.');
+        }
+        return response.json();
+      })
+      .then(function (dados) {
+        prepararProcessos(dados);
+      })
+      .catch(function (erro) {
+        console.warn('Falha ao obter processos via fetch, tentando dados incorporados.', erro);
+        const dadosIncorporados = obterDadosIncorporados();
+        if (dadosIncorporados) {
+          prepararProcessos(dadosIncorporados);
+          return;
+        }
+        exibirMensagemErro('Não foi possível carregar os processos.');
+      });
+
+  }
+
+  function obterDadosIncorporados() {
+    if (typeof window !== 'undefined' && Array.isArray(window.PROCESSOS_DATA)) {
+      return window.PROCESSOS_DATA;
+    }
+    return null;
+  }
+
+  function prepararProcessos(dados) {
+    if (!Array.isArray(dados)) {
+      exibirMensagemErro('Não foi possível carregar os processos.');
+      return;
+    }
+
+    processos = dados.map(function (processo, index) {
+      const valorNumerico = parseCurrency(processo.valor_causa);
+      const etapa = determinarEtapa(processo, index, columns);
+
+      return Object.assign({}, processo, {
+        etapa: etapa,
+        etapaNome: obterNomeEtapa(etapa, columns),
+        valorNumerico: valorNumerico,
+        valorFormatado: Number.isFinite(valorNumerico)
+          ? moedaFormatter.format(valorNumerico)
+          : processo.valor_causa
+      });
+    });
+
+    popularFiltroStatus(processos, statusFilter);
+    renderizarQuadro();
+  }
+
+  function registrarEventos() {
+    if (statusFilter) {
+      statusFilter.addEventListener('change', function (event) {
+        filtrosAtivos.status = event.target.value;
+        renderizarQuadro();
+      });
+    }
+
+    if (sortFilter) {
+      sortFilter.addEventListener('change', function (event) {
+        filtrosAtivos.sort = event.target.value;
+        renderizarQuadro();
+      });
+    }
+
+    if (searchInput) {
+      searchInput.addEventListener('input', function (event) {
+        filtrosAtivos.search = event.target.value.trim().toLowerCase();
+        renderizarQuadro();
+      });
+    }
+
+    if (clearFiltersButton) {
+      clearFiltersButton.addEventListener('click', function () {
+        filtrosAtivos = { status: 'all', search: '', sort: 'recent' };
+        if (statusFilter) {
+          statusFilter.value = 'all';
+        }
+        if (sortFilter) {
+          sortFilter.value = 'recent';
+        }
+        if (searchInput) {
+          searchInput.value = '';
+        }
+        renderizarQuadro();
+      });
+    }
+
+    viewToggleButtons.forEach(function (botao) {
+      botao.addEventListener('click', function () {
+        const destino = botao.getAttribute('data-view-toggle');
+        alternarVisualizacao(destino);
+      });
+    });
+
+    if (reloadButton) {
+      reloadButton.addEventListener('click', function () {
+        if (typeof window !== 'undefined' && window.location) {
+          window.location.reload();
+        }
+      });
+    }
+  }
+
+  function renderizarQuadro() {
+    const comparator = obterComparador(filtrosAtivos.sort);
+    const processosFiltrados = processos
+      .filter(function (processo) {
+        return filtrarPorStatus(processo, filtrosAtivos.status);
+      })
+      .filter(function (processo) {
+        return filtrarPorPesquisa(processo, filtrosAtivos.search);
+      });
+
+    const contagemTotal = processosFiltrados.length;
+    if (totalProcessosChip) {
+      totalProcessosChip.textContent = contagemTotal +
+        ' processo' + (contagemTotal === 1 ? '' : 's');
+    }
+
+    renderizarLista(processosFiltrados, comparator);
+
+    const processosPorColuna = agruparPorColuna(processosFiltrados, comparator, columns);
+
+    columns.forEach(function (column) {
+      const id = column.id;
+      const coluna = columnElements.get(id);
+      if (!coluna) {
+        return;
+      }
+
+      const lista = coluna.querySelector('.column-cards');
+      const contador = coluna.querySelector('[data-count]');
+      const itens = processosPorColuna.get(id) || [];
+
+      lista.innerHTML = '';
+
+      if (!itens.length) {
+        const vazio = document.createElement('div');
+        vazio.className = 'empty-column';
+        vazio.textContent = 'Nenhum processo nesta etapa.';
+        lista.appendChild(vazio);
+      } else {
+        itens.forEach(function (processo) {
+          lista.appendChild(criarCardProcesso(processo));
+        });
+      }
+
+      if (contador) {
+        contador.textContent = itens.length;
+      }
+    });
+  }
+
+  function agruparPorColuna(processosFiltrados, comparator, columnsReference) {
+    const mapa = new Map(columnsReference.map(function (coluna) {
+      return [coluna.id, []];
+    }));
+
+    processosFiltrados.forEach(function (processo) {
+      const colunaAtual = mapa.get(processo.etapa);
+      if (!colunaAtual) {
+        mapa.set(processo.etapa, [processo]);
+        return;
+      }
+      colunaAtual.push(processo);
+    });
+
+    mapa.forEach(function (itens) {
+      itens.sort(comparator);
+    });
+
+    return mapa;
+  }
+
+  function filtrarPorStatus(processo, statusAtual) {
+    if (statusAtual === 'all') {
+      return true;
+    }
+    const statusProcesso = processo.status ? processo.status.toLowerCase() : '';
+    return statusProcesso === statusAtual;
+  }
+
+  function filtrarPorPesquisa(processo, termo) {
+    if (!termo) {
+      return true;
+    }
+
+    const campos = [
+      processo.nome_reu,
+      processo.cpf_cnpj_reu,
+      processo.numero_processo,
+      processo.status
+    ]
+      .filter(function (valor) {
+        return Boolean(valor);
+      })
+      .map(function (valor) {
+        return valor.toString().toLowerCase();
+      });
+
+    return campos.some(function (campo) {
+      return campo.indexOf(termo) !== -1;
+    });
+  }
+
+  function obterComparador(tipoOrdenacao) {
+    switch (tipoOrdenacao) {
+      case 'valor-desc':
+        return function (a, b) {
+          return (b.valorNumerico || 0) - (a.valorNumerico || 0);
+        };
+      case 'valor-asc':
+        return function (a, b) {
+          return (a.valorNumerico || 0) - (b.valorNumerico || 0);
+        };
+      case 'alfabetico':
+        return function (a, b) {
+          return a.nome_reu.localeCompare(b.nome_reu, 'pt');
+        };
+      case 'recent':
+      default:
+        return function (a, b) {
+          return (b.id || 0) - (a.id || 0);
+        };
+    }
+  }
+
+  function criarCardProcesso(processo) {
+    const card = document.createElement('article');
+    card.className = 'deal-card';
+    card.setAttribute('role', 'listitem');
+
+    const cabecalho = document.createElement('header');
+    cabecalho.className = 'deal-card__header';
+
+    const status = document.createElement('span');
+    status.className = 'deal-card__status';
+    status.textContent = processo.status || 'Sem status';
+
+    const valor = document.createElement('span');
+    valor.className = 'deal-card__value';
+    valor.textContent = processo.valorFormatado || '—';
+
+    cabecalho.append(status, valor);
+
+    const titulo = document.createElement('h3');
+    titulo.className = 'deal-card__title';
+    titulo.textContent = processo.nome_reu || 'Cliente sem nome';
+    titulo.title = processo.nome_reu || '';
+
+    const meta = document.createElement('div');
+    meta.className = 'deal-card__meta';
+
+    const processoSpan = document.createElement('span');
+    const processoLabel = document.createElement('strong');
+    processoLabel.textContent = 'Processo:';
+    processoSpan.append(
+      processoLabel,
+      document.createTextNode(' ' + formatarNumeroProcesso(processo.numero_processo))
+    );
+
+    const documentoSpan = document.createElement('span');
+    const documentoLabel = document.createElement('strong');
+    documentoLabel.textContent = 'CPF/CNPJ:';
+    documentoSpan.append(
+      documentoLabel,
+      document.createTextNode(' ' + (processo.cpf_cnpj_reu || 'Não informado'))
+    );
+
+    meta.append(processoSpan, documentoSpan);
+
+    const rodape = document.createElement('footer');
+    rodape.className = 'deal-card__footer';
+
+    const etapaPill = document.createElement('span');
+    etapaPill.className = 'card-pill';
+    etapaPill.textContent = processo.etapaNome;
+
+    const actions = document.createElement('div');
+    actions.className = 'card-actions';
+
+    const visualizar = document.createElement('button');
+    visualizar.type = 'button';
+    visualizar.setAttribute('aria-label', 'Abrir detalhes do processo ' + processo.numero_processo);
+    visualizar.textContent = '👁';
+
+    const lembrar = document.createElement('button');
+    lembrar.type = 'button';
+    lembrar.setAttribute('aria-label', 'Adicionar lembrete para ' + (processo.nome_reu || 'o cliente'));
+    lembrar.textContent = '⏰';
+
+    const menu = document.createElement('button');
+    menu.type = 'button';
+    menu.setAttribute('aria-label', 'Mais opções para ' + (processo.nome_reu || 'o cliente'));
+    menu.textContent = '⋯';
+
+    actions.append(visualizar, lembrar, menu);
+    rodape.append(etapaPill, actions);
+
+    card.append(cabecalho, titulo, meta, rodape);
+    return card;
+  }
+
+  function renderizarLista(processosFiltrados, comparator) {
+    if (!listView) {
+      return;
+    }
+
+    listView.innerHTML = '';
+
+    if (!processosFiltrados.length) {
+      const vazio = document.createElement('div');
+      vazio.className = 'board-list__empty';
+      vazio.textContent = 'Nenhum processo encontrado.';
+      listView.appendChild(vazio);
+      return;
+    }
+
+    const tabela = document.createElement('table');
+    tabela.className = 'board-list__table';
+
+    const cabecalho = document.createElement('thead');
+    const linhaCabecalho = document.createElement('tr');
+    ['ID', 'Nº Processo', 'Réu', 'CPF/CNPJ', 'Valor da Causa (R$)', 'Status'].forEach(function (titulo) {
+      const th = document.createElement('th');
+      th.scope = 'col';
+      th.textContent = titulo;
+      linhaCabecalho.appendChild(th);
+    });
+    cabecalho.appendChild(linhaCabecalho);
+
+    const corpo = document.createElement('tbody');
+    const itensOrdenados = processosFiltrados.slice().sort(comparator);
+
+    itensOrdenados.forEach(function (processo) {
+      const linha = document.createElement('tr');
+
+      const celulaId = document.createElement('td');
+      celulaId.textContent = processo.id || '—';
+
+      const celulaNumero = document.createElement('td');
+      celulaNumero.textContent = formatarNumeroProcesso(processo.numero_processo);
+
+      const celulaReu = document.createElement('td');
+      celulaReu.textContent = processo.nome_reu || 'Cliente sem nome';
+
+      const celulaDocumento = document.createElement('td');
+      celulaDocumento.textContent = processo.cpf_cnpj_reu || 'Não informado';
+
+      const celulaValor = document.createElement('td');
+      celulaValor.textContent = processo.valorFormatado || processo.valor_causa || '—';
+
+      const celulaStatus = document.createElement('td');
+      const badgeStatus = document.createElement('span');
+      badgeStatus.className = 'status-badge';
+      const statusNormalizado = (processo.status || '').toLowerCase();
+      badgeStatus.textContent = statusNormalizado ? capitalizar(statusNormalizado) : 'Sem status';
+      celulaStatus.appendChild(badgeStatus);
+
+      linha.append(celulaId, celulaNumero, celulaReu, celulaDocumento, celulaValor, celulaStatus);
+      corpo.appendChild(linha);
+    });
+
+    tabela.append(cabecalho, corpo);
+    listView.appendChild(tabela);
+  }
+
+  function parseCurrency(valor) {
+    if (!valor) {
+      return NaN;
+    }
+    const normalizado = valor
+      .toString()
+      .replace(/[^0-9,-]+/g, '')
+      .replace(/\./g, '')
+      .replace(',', '.');
+
+    return Number.parseFloat(normalizado);
+  }
+
+  function determinarEtapa(processo, indice, columnsReference) {
+    const statusNormalizado = (processo.status || '').toLowerCase();
+
+    if (statusNormalizado.indexOf('final') !== -1) {
+      return 'finalizados';
+    }
+    if (statusNormalizado.indexOf('aguard') !== -1) {
+      return 'aguardando';
+    }
+    if (statusNormalizado.indexOf('aprov') !== -1) {
+      return 'orcamento-aprovado';
+    }
+    if (statusNormalizado.indexOf('orç') !== -1 || statusNormalizado.indexOf('orc') !== -1) {
+      return 'orcamento-proposta';
+    }
+    if (statusNormalizado.indexOf('atend') !== -1) {
+      return 'em-atendimento';
+    }
+
+    const colunaAlternativa = columnsReference[indice % columnsReference.length];
+    return colunaAlternativa ? colunaAlternativa.id : columnsReference[0].id;
+  }
+
+  function obterNomeEtapa(id, columnsReference) {
+    for (let i = 0; i < columnsReference.length; i += 1) {
+      if (columnsReference[i].id === id) {
+        return columnsReference[i].label;
+      }
+    }
+    return 'Etapa não definida';
+  }
+
+  function popularFiltroStatus(listaProcessos, selectElement) {
+    if (!selectElement) {
+      return;
+    }
+
+    while (selectElement.options.length > 1) {
+      selectElement.remove(1);
+    }
+
+    const statusUnicos = Array.from(
+      new Set(
+        listaProcessos
+          .map(function (processo) {
+            return processo.status;
+          })
+          .filter(function (status) {
+            return Boolean(status);
+          })
+          .map(function (status) {
+            return status.toLowerCase();
+          })
+      )
+    ).sort();
+
+    statusUnicos.forEach(function (status) {
+      const option = document.createElement('option');
+      option.value = status;
+      option.textContent = capitalizar(status);
+      selectElement.appendChild(option);
+    });
+  }
+
+  function capitalizar(texto) {
+    return texto
+      .split(' ')
+      .filter(function (parte) {
+        return parte.trim().length > 0;
+      })
+      .map(function (parte) {
+        return parte.charAt(0).toUpperCase() + parte.slice(1);
+      })
+      .join(' ');
+  }
+
+  function formatarNumeroProcesso(numero) {
+    if (!numero) {
+      return '—';
+    }
+    return numero.toString().replace(/(\d{4})(?=\d)/g, '$1 ');
+  }
+
+  function exibirMensagemErro(mensagem) {
+    const board = document.querySelector('.board');
+    if (!board) {
+      return;
+    }
+    board.innerHTML = '';
+    const aviso = document.createElement('div');
+    aviso.className = 'empty-column';
+    aviso.textContent = mensagem;
+    board.appendChild(aviso);
+    if (listView) {
+      listView.innerHTML = '';
+      const avisoLista = document.createElement('div');
+      avisoLista.className = 'board-list__empty';
+      avisoLista.textContent = mensagem;
+      listView.appendChild(avisoLista);
+    }
+  }
+
+  function alternarVisualizacao(destino) {
+    if (destino !== 'list' && destino !== 'board') {
+      destino = 'board';
+    }
+
+    currentView = destino;
+    atualizarVisibilidadeVisualizacao();
+    atualizarBotoesVisualizacao();
+  }
+
+  function atualizarVisibilidadeVisualizacao() {
+    if (boardView) {
+      boardView.hidden = currentView !== 'board';
+    }
+    if (listView) {
+      listView.hidden = currentView !== 'list';
+    }
+  }
+
+  function atualizarBotoesVisualizacao() {
+    viewToggleButtons.forEach(function (botao) {
+      const modo = botao.getAttribute('data-view-toggle');
+      const ativo = modo === currentView;
+      botao.classList.toggle('is-active', ativo);
+      botao.setAttribute('aria-pressed', ativo ? 'true' : 'false');
+    });
+  }
+})();

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,0 +1,51 @@
+@extends('layouts.app')
+
+@section('title', 'Entrar | SGPJ')
+@section('body-class', 'auth-page')
+
+@section('content')
+  <div class="login-screen">
+    <section class="login-card" role="dialog" aria-modal="true">
+      <header class="login-card__header">
+        <div class="login-brand">SGPJ</div>
+        <h1 class="login-title">Bem-vindo de volta</h1>
+        <p class="login-subtitle">Acesse o painel com suas credenciais autorizadas.</p>
+      </header>
+      <form class="login-form" method="POST" action="{{ route('login.submit') }}" novalidate>
+        @csrf
+        <label class="login-field" for="username">
+          <span>Usuário</span>
+          <input
+            type="text"
+            id="username"
+            name="username"
+            autocomplete="username"
+            placeholder="Digite tarcisio ou lucas"
+            value="{{ old('username') }}"
+            required
+          />
+        </label>
+        <label class="login-field" for="password">
+          <span>Senha</span>
+          <input
+            type="password"
+            id="password"
+            name="password"
+            autocomplete="current-password"
+            placeholder="Digite 123"
+            required
+          />
+        </label>
+        <label class="login-remember" for="remember">
+          <input type="checkbox" id="remember" name="remember" value="1" {{ old('remember') ? 'checked' : '' }} />
+          <span>Lembrar-me neste dispositivo</span>
+        </label>
+        <button class="login-submit" type="submit">Entrar</button>
+        <p class="login-hint">Usuários autorizados: tarcisio · lucas — senha: 123</p>
+        @if ($errors->any())
+          <p class="login-error" role="alert" aria-live="polite">{{ $errors->first() }}</p>
+        @endif
+      </form>
+    </section>
+  </div>
+@endsection

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -1,0 +1,243 @@
+@extends('layouts.app')
+
+@section('title', 'SGPJ')
+
+@push('head')
+  <meta name="processos-endpoint" content="{{ route('processos.index') }}" />
+  <meta name="home-url" content="{{ route('dashboard') }}" />
+@endpush
+
+@section('content')
+  <div class="app-shell" id="app-shell">
+    <header class="app-header">
+      <div class="header-left">
+        <button
+          class="icon-button"
+          type="button"
+          aria-label="Alternar menu"
+          data-drawer-toggle
+          aria-expanded="false"
+        >
+          <span aria-hidden="true">☰</span>
+        </button>
+        <div class="product-logo" aria-hidden="true">P</div>
+        <div class="header-title-group">
+          <span class="header-eyebrow">SGPJ</span>
+          <h1 class="header-title">Causas</h1>
+          <span class="header-subtitle">Bancárias</span>
+        </div>
+        <span class="header-user" id="logged-user">Olá, <strong>{{ $usuario }}</strong></span>
+        <span class="header-chip" id="total-processos">0 processos</span>
+      </div>
+      <div class="header-actions">
+        <button
+          class="icon-button"
+          type="button"
+          aria-label="Visualização em lista"
+          data-view-toggle="list"
+          aria-pressed="false"
+        >
+          <span aria-hidden="true">☷</span>
+        </button>
+        <button
+          class="icon-button is-active"
+          type="button"
+          aria-label="Visualização em quadro"
+          data-view-toggle="board"
+          aria-pressed="true"
+        >
+          <span aria-hidden="true">▦</span>
+        </button>
+        <button class="icon-button icon-button--reload" type="button" aria-label="Recarregar dados" data-reload>
+          <span aria-hidden="true">⟲</span>
+        </button>
+      </div>
+    </header>
+
+    <section class="board-toolbar" aria-label="Opções da visualização">
+      <div class="toolbar-tabs" role="tablist" aria-label="Filtros rápidos">
+        <button class="tab is-active" role="tab" aria-selected="true">Todas as negociações</button>
+        <button class="tab" role="tab" aria-selected="false">Bancárias</button>
+        <button class="tab" role="tab" aria-selected="false">Empresáriais</button>
+        <button class="tab" role="tab" aria-selected="false">Busca E apreensão</button>
+      </div>
+      <div class="toolbar-actions">
+        <button class="icon-button" type="button" aria-label="Exportar quadro">
+          <span aria-hidden="true">⤓</span>
+        </button>
+        <button class="icon-button" type="button" aria-label="Configurações" data-drawer-action="settings">
+          <span aria-hidden="true">⚙</span>
+        </button>
+      </div>
+    </section>
+
+    <section class="filters" aria-label="Filtros do quadro">
+      <label class="filter">
+        <span class="filter-label">Funil</span>
+        <select id="pipeline-filter">
+          <option value="all">Todos os funis</option>
+          <option value="funil-os" selected>Funil OS</option>
+        </select>
+      </label>
+      <label class="filter">
+        <span class="filter-label">Status</span>
+        <select id="status-filter">
+          <option value="all">Todos os status</option>
+        </select>
+      </label>
+      <label class="filter">
+        <span class="filter-label">Ordenar</span>
+        <select id="sort-filter">
+          <option value="recent">Criados por último</option>
+          <option value="valor-desc">Maior valor</option>
+          <option value="valor-asc">Menor valor</option>
+          <option value="alfabetico">Ordem alfabética</option>
+        </select>
+      </label>
+      <label class="filter filter--search">
+        <span class="filter-label">Buscar</span>
+        <input
+          id="search-input"
+          type="search"
+          placeholder="Procurar por cliente, CPF/CNPJ ou nº do processo"
+          autocomplete="off"
+        />
+      </label>
+      <button class="ghost-button" type="button" id="clear-filters">Limpar filtros</button>
+    </section>
+
+    <main class="board" id="board-view" aria-label="Quadro de processos">
+      <section class="board-column" data-column="em-atendimento">
+        <header class="column-header">
+          <div class="column-title">
+            <span class="column-dot" aria-hidden="true"></span>
+            <h2>Recebidos</h2>
+          </div>
+          <span class="column-count" data-count>0</span>
+        </header>
+        <div class="column-cards" role="list"></div>
+      </section>
+
+      <section class="board-column" data-column="orcamento-proposta">
+        <header class="column-header">
+          <div class="column-title">
+            <span class="column-dot" aria-hidden="true"></span>
+            <h2>Em progresso</h2>
+          </div>
+          <span class="column-count" data-count>0</span>
+        </header>
+        <div class="column-cards" role="list"></div>
+      </section>
+
+      <section class="board-column" data-column="orcamento-aprovado">
+        <header class="column-header">
+          <div class="column-title">
+            <span class="column-dot" aria-hidden="true"></span>
+            <h2>Veredito</h2>
+          </div>
+          <span class="column-count" data-count>0</span>
+        </header>
+        <div class="column-cards" role="list"></div>
+      </section>
+
+      <section class="board-column" data-column="aguardando">
+        <header class="column-header">
+          <div class="column-title">
+            <span class="column-dot" aria-hidden="true"></span>
+            <h2>Aguardando Juiz</h2>
+          </div>
+          <span class="column-count" data-count>0</span>
+        </header>
+        <div class="column-cards" role="list"></div>
+      </section>
+
+      <section class="board-column" data-column="finalizados">
+        <header class="column-header">
+          <div class="column-title">
+            <span class="column-dot" aria-hidden="true"></span>
+            <h2>Concluídos</h2>
+          </div>
+          <span class="column-count" data-count>0</span>
+        </header>
+        <div class="column-cards" role="list"></div>
+      </section>
+    </main>
+
+    <section class="board-list" id="board-list" aria-label="Lista de processos" hidden></section>
+
+    <button class="help-button" type="button">
+      <span aria-hidden="true">?</span>
+      <span>Ajuda</span>
+    </button>
+  </div>
+
+  <div class="drawer-overlay" id="drawer-overlay" hidden></div>
+  <aside class="side-drawer" id="side-drawer" aria-hidden="true">
+    <div class="side-drawer__header">
+      <span class="side-drawer__title">Menu</span>
+      <button class="icon-button side-drawer__close" type="button" id="drawer-close" aria-label="Fechar menu">
+        <span aria-hidden="true">×</span>
+      </button>
+    </div>
+    <nav class="side-drawer__nav" aria-label="Menu principal">
+      <ul class="side-drawer__list">
+        <li>
+          <button class="side-drawer__link" type="button" data-drawer-action="home">Início</button>
+        </li>
+        <li>
+          <button class="side-drawer__link" type="button" data-drawer-action="report">Reporte um erro</button>
+        </li>
+        <li>
+          <button
+            class="side-drawer__link"
+            type="button"
+            data-drawer-action="settings"
+            aria-controls="drawer-settings"
+            aria-expanded="false"
+          >
+            Configurações
+          </button>
+        </li>
+        <li>
+          <button class="side-drawer__link" type="button" data-drawer-action="about">Sobre nós</button>
+        </li>
+        <li>
+          <button class="side-drawer__link" type="button" data-drawer-action="logout">Sair</button>
+        </li>
+      </ul>
+    </nav>
+    <div class="side-drawer__settings" id="drawer-settings" hidden aria-hidden="true">
+      <span class="side-drawer__settings-title">Preferências</span>
+      <div class="settings-toggle">
+        <div class="settings-toggle__text">
+          <label class="settings-toggle__title" for="theme-toggle" id="theme-toggle-label">Modo escuro</label>
+          <p class="settings-toggle__description" id="theme-toggle-description">
+            Ativa uma paleta escura em todo o painel.
+          </p>
+        </div>
+        <div class="settings-toggle__control">
+          <input
+            type="checkbox"
+            class="switch__input"
+            id="theme-toggle"
+            role="switch"
+            aria-labelledby="theme-toggle-label"
+            aria-describedby="theme-toggle-description"
+            aria-checked="false"
+          />
+          <span class="switch" aria-hidden="true">
+            <span class="switch__thumb"></span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </aside>
+
+  <form id="logout-form" action="{{ route('logout') }}" method="POST" class="visually-hidden">
+    @csrf
+  </form>
+@endsection
+
+@push('scripts')
+  <script src="{{ asset('js/dashboard.js') }}" defer></script>
+@endpush

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>@yield('title', 'SGPJ')</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="{{ asset('css/app.css') }}" />
+    @stack('head')
+  </head>
+  <body class="@yield('body-class')">
+    @yield('content')
+
+    @stack('scripts')
+  </body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,13 @@
+<?php
+
+use App\Http\Controllers\AuthController;
+use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\ProcessoController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/login', [AuthController::class, 'showLoginForm'])->name('login');
+Route::post('/login', [AuthController::class, 'login'])->name('login.submit');
+Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
+
+Route::get('/', [DashboardController::class, 'index'])->name('dashboard');
+Route::get('/processos', [ProcessoController::class, 'index'])->name('processos.index');

--- a/storage/app/sgpj/processos.json
+++ b/storage/app/sgpj/processos.json
@@ -1,0 +1,802 @@
+[
+  {
+    "id": 326,
+    "numero_processo": "10130693920248260100",
+    "nome_reu": "TO DE EMPRÉSTIMO – CAGIRO REORGANIZAÇÃO FINANCEIRA EM 07/07/2022",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 351.570,93",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 365,
+    "numero_processo": "10699500220258260100",
+    "nome_reu": "TOS",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 349.515,71",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 190,
+    "numero_processo": "10513327720238260100",
+    "nome_reu": "ROSA DO LIBANO RESTAURANTE UNIPESSOAL LTDA ME (ANTIGA DENOMINAÇÃO ROSA DO LIBANO RESTAURANTE LTDA)",
+    "cpf_cnpj_reu": "20512824000158",
+    "valor_causa": "R$ 348.773,31",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 61,
+    "numero_processo": "11148758820228260100",
+    "nome_reu": "SWEET FRIENDS COMERCIO DE ALIMENTOS LTDA",
+    "cpf_cnpj_reu": "14697598000124",
+    "valor_causa": "R$ 347.825,08",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 351,
+    "numero_processo": "10057094320248260071",
+    "nome_reu": "FACE DE PRISCILA EMILIO DE OLIVEIRA ANDRADE",
+    "cpf_cnpj_reu": "32215375817",
+    "valor_causa": "R$ 347.325,25",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 416,
+    "numero_processo": "10444872920238260100",
+    "nome_reu": "TOS",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 344.415,64",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 574,
+    "numero_processo": "10705595620238260002",
+    "nome_reu": "SILVIO LUIZ MEDEIROS",
+    "cpf_cnpj_reu": "22442744899",
+    "valor_causa": "R$ 343.215,96",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 237,
+    "numero_processo": "10719423220248260100",
+    "nome_reu": "CAIO HENRIQUE CAPRIOLI",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 340.417,07",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 578,
+    "numero_processo": "11377441120238260100",
+    "nome_reu": "CHRISTINA COMRIAN",
+    "cpf_cnpj_reu": "25453861894",
+    "valor_causa": "R$ 339.288,77",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 114,
+    "numero_processo": "10247552820248260100",
+    "nome_reu": "SAM COSMETICO LTDA",
+    "cpf_cnpj_reu": "44617461000183",
+    "valor_causa": "R$ 337.738,59",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 355,
+    "numero_processo": "10587814420238260114",
+    "nome_reu": "P C DA SILVA CONSTRUÇÕES",
+    "cpf_cnpj_reu": "31691927000149",
+    "valor_causa": "R$ 337.270,98",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 78,
+    "numero_processo": "10680092720198260100",
+    "nome_reu": "POLIETINE COMERCIAL E DISTRIBUIDORA — EIRELI - EPP",
+    "cpf_cnpj_reu": "27435272000170",
+    "valor_causa": "R$ 336.993,76",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 192,
+    "numero_processo": "10434540420238260100",
+    "nome_reu": "TRIBOS IMPORTAÇÃO E EXPORTAÇÃO LTDA ME",
+    "cpf_cnpj_reu": "43966133000120",
+    "valor_causa": "R$ 336.048,23",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 270,
+    "numero_processo": "10332413620238260100",
+    "nome_reu": "CECILIA MIZIARA DE CASTRO BRITO",
+    "cpf_cnpj_reu": "01225230160",
+    "valor_causa": "R$ 333.920,74",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 471,
+    "numero_processo": "10762510920188260100",
+    "nome_reu": "BANCO PAN S.A",
+    "cpf_cnpj_reu": "59285411000113",
+    "valor_causa": "R$ 331.865,53",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 794,
+    "numero_processo": "10855072920258260100",
+    "nome_reu": "LAERCIO FRANCISCO RICCO JUNIOR",
+    "cpf_cnpj_reu": "15726567862",
+    "valor_causa": "R$ 331.219,32",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 8,
+    "numero_processo": "10112130620258260100",
+    "nome_reu": "GENTE PEQUENA COMERCIO E CONFECCOES LTDA",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 330.737,85",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 287,
+    "numero_processo": "10515576820218260100",
+    "nome_reu": "JUNG HEE KI",
+    "cpf_cnpj_reu": "23386235840",
+    "valor_causa": "R$ 329.171,74",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 870,
+    "numero_processo": "10609643020238260100",
+    "nome_reu": "1) MATEUS NAREZZI CÂNDIDO 42371519804",
+    "cpf_cnpj_reu": "42371519804",
+    "valor_causa": "R$ 328.830,00",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 333,
+    "numero_processo": "10384499820238260100",
+    "nome_reu": "CAYK RODRIGO BERNARDO DE OLIVEIRA",
+    "cpf_cnpj_reu": "35783495859",
+    "valor_causa": "R$ 327.127,74",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 210,
+    "numero_processo": "11443725020228260100",
+    "nome_reu": "JOÃO ROSA SANTANA",
+    "cpf_cnpj_reu": "25355661840",
+    "valor_causa": "R$ 326.615,54",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 405,
+    "numero_processo": "10294875220248260100",
+    "nome_reu": "TO DE EMPRÉSTIMO – CRÉDITO PESSOAL EM 22/08/2022",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 325.734,67",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 163,
+    "numero_processo": "10093366520248260100",
+    "nome_reu": "MARCOS ALEXANDRE RAMOS MOTTA DA SILVA",
+    "cpf_cnpj_reu": "49616832808",
+    "valor_causa": "R$ 324.586,18",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 59,
+    "numero_processo": "11176446920228260100",
+    "nome_reu": "CARLA PACHECO",
+    "cpf_cnpj_reu": "29378101879",
+    "valor_causa": "R$ 324.275,90",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 407,
+    "numero_processo": "11579487620238260100",
+    "nome_reu": "TUAIS",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 322.828,75",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 418,
+    "numero_processo": "10231213120238260100",
+    "nome_reu": "MARINALVA BARROS DA ROCHA DE OLIVEIRA LI",
+    "cpf_cnpj_reu": "18517462000146",
+    "valor_causa": "R$ 322.276,49",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 133,
+    "numero_processo": "10891040620258260100",
+    "nome_reu": "STEFANO VIOLA",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 321.691,97",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 840,
+    "numero_processo": "10813686820248260100",
+    "nome_reu": "EMPORIO GRAO BENEDITO LTDA",
+    "cpf_cnpj_reu": "35337365000190",
+    "valor_causa": "R$ 320.218,71",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 503,
+    "numero_processo": "10085630220258260127",
+    "nome_reu": "Não encontrado",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 319.057,79",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 184,
+    "numero_processo": "10753255220238260100",
+    "nome_reu": "AN09 DISTRIBUIDORA DE PRODUTOS ESPORTIVO",
+    "cpf_cnpj_reu": "34955217000177",
+    "valor_causa": "R$ 315.271,73",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 875,
+    "numero_processo": "10286191120238260100",
+    "nome_reu": "ADRIANO HERCULANO DOS SANTOS",
+    "cpf_cnpj_reu": "01053942460",
+    "valor_causa": "R$ 315.000,00",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 465,
+    "numero_processo": "10130059420228260004",
+    "nome_reu": "PHILLIPE GUINE BIRAL",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 314.607,81",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 249,
+    "numero_processo": "11331808620238260100",
+    "nome_reu": "MOHAMAD SOUHEIL EL SAHILI",
+    "cpf_cnpj_reu": "23720486869",
+    "valor_causa": "R$ 313.372,24",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 313,
+    "numero_processo": "10257552920258260100",
+    "nome_reu": ": BARTOLOMEU LUIZ OLIVEIRA",
+    "cpf_cnpj_reu": "05564733703",
+    "valor_causa": "R$ 312.734,96",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 670,
+    "numero_processo": "10035279420258260024",
+    "nome_reu": "VINICIUS DE OLIVEIRA SILVA",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 312.565,88",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 247,
+    "numero_processo": "11467019820238260100",
+    "nome_reu": "FREE TRANSIT INTERMEDIACAO DE NEGOCIOS L",
+    "cpf_cnpj_reu": "09481932000178",
+    "valor_causa": "R$ 310.952,84",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 30,
+    "numero_processo": "10182918520248260100",
+    "nome_reu": "TRON COMERCIO DE ARTIGOS DE INFORMATICA",
+    "cpf_cnpj_reu": "24347099000160",
+    "valor_causa": "R$ 309.806,39",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 68,
+    "numero_processo": "10349573520228260100",
+    "nome_reu": "RONALDO FURLAN ESTORARI",
+    "cpf_cnpj_reu": "21701631822",
+    "valor_causa": "R$ 305.599,37",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 79,
+    "numero_processo": "11320650620188260100",
+    "nome_reu": "COMERCIAL JP IMPORTACAO E EXPORTACAO LTDA",
+    "cpf_cnpj_reu": "27530207000124",
+    "valor_causa": "R$ 302.893,20",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 231,
+    "numero_processo": "00059467020258260100",
+    "nome_reu": "Não encontrado",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 302.528,64",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 549,
+    "numero_processo": "10711386420248260100",
+    "nome_reu": "ITAPEVA XII MULTICARTEIRA FUNDO DE INVESTIMENTO EM DIREITOS CREDITORIOS NAO- PADRONIZADOS",
+    "cpf_cnpj_reu": "30366229000105",
+    "valor_causa": "R$ 301.899,36",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 228,
+    "numero_processo": "10398705520258260100",
+    "nome_reu": "ALLYSSON DEYVID CAVALCANTE ARAUJO",
+    "cpf_cnpj_reu": "01506261426",
+    "valor_causa": "R$ 301.535,22",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 328,
+    "numero_processo": "11072818620238260100",
+    "nome_reu": "ECHONOMIDIA COMERCIO LTDA",
+    "cpf_cnpj_reu": "10371321000156",
+    "valor_causa": "R$ 300.410,19",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 22,
+    "numero_processo": "11307823520248260100",
+    "nome_reu": "CONEX SERVICOS LTDA (ANTIGA CONEX COMERCIAL E DISTRIBUIDORA LTDA)",
+    "cpf_cnpj_reu": "37177146000117",
+    "valor_causa": "R$ 297.356,11",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 734,
+    "numero_processo": "10469842120208260100",
+    "nome_reu": "CONFRONTO DE ALUMINI ENGENHARIA S/A",
+    "cpf_cnpj_reu": "58580465000149",
+    "valor_causa": "R$ 296.809,46",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 39,
+    "numero_processo": "11306172220238260100",
+    "nome_reu": "OLAVO PLESSMANN BAYEUX",
+    "cpf_cnpj_reu": "12559177846",
+    "valor_causa": "R$ 296.561,39",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 757,
+    "numero_processo": "10103524120228260127",
+    "nome_reu": "JOSE RODRIGUES LOPES",
+    "cpf_cnpj_reu": "56698275891",
+    "valor_causa": "R$ 295.872,66",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 124,
+    "numero_processo": "11247724320228260100",
+    "nome_reu": "LR INFORMÁTICA E ELETRÔNICOS EIRELI",
+    "cpf_cnpj_reu": "42639460000104",
+    "valor_causa": "R$ 294.447,97",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 275,
+    "numero_processo": "11348249820228260100",
+    "nome_reu": "HELMUT JOSE FERRAZ FLADT",
+    "cpf_cnpj_reu": "09317073824",
+    "valor_causa": "R$ 294.084,37",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 81,
+    "numero_processo": "10825375620258260100",
+    "nome_reu": "INOVAÇÃO 360 MARKETING LTDA",
+    "cpf_cnpj_reu": "55588308000191",
+    "valor_causa": "R$ 291.213,14",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 338,
+    "numero_processo": "11380727220228260100",
+    "nome_reu": "BRONKS INDUSTRIA E COMERCIO DE ROUPAS E ACESSORIOS EIRELI",
+    "cpf_cnpj_reu": "21001510000153",
+    "valor_causa": "R$ 290.948,17",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 250,
+    "numero_processo": "11331756420238260100",
+    "nome_reu": "CELSO DE LIMA BUZZONI",
+    "cpf_cnpj_reu": "67460119849",
+    "valor_causa": "R$ 289.801,32",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 751,
+    "numero_processo": "10217133820228260068",
+    "nome_reu": "JOSE RODOLFO SILVERIO",
+    "cpf_cnpj_reu": "28273093867",
+    "valor_causa": "R$ 288.470,07",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 202,
+    "numero_processo": "10191954220238260100",
+    "nome_reu": "CARLOS ANTONIO DIAS SILVA REIS",
+    "cpf_cnpj_reu": "03455601839",
+    "valor_causa": "R$ 286.107,63",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 278,
+    "numero_processo": "11179044920228260100",
+    "nome_reu": "RENATO SILVEIRA LIMA",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 285.470,59",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 138,
+    "numero_processo": "10607272520258260100",
+    "nome_reu": "CAREVA MANUTENCAO EM EQUIPAMENTOS LTDA EPP",
+    "cpf_cnpj_reu": "60514593000136",
+    "valor_causa": "R$ 285.136,95",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 508,
+    "numero_processo": "10018597620258260222",
+    "nome_reu": "Não encontrado",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 284.123,04",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 811,
+    "numero_processo": "10339778320258260100",
+    "nome_reu": "DANIEL CHOI",
+    "cpf_cnpj_reu": "32488426873",
+    "valor_causa": "R$ 281.695,00",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 678,
+    "numero_processo": "10376769820258260224",
+    "nome_reu": ": VOLKSWAGEN SERVIÇOS FINANCEIROS LTDA",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 281.156,12",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 380,
+    "numero_processo": "10238672520258260100",
+    "nome_reu": "TOS",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 281.040,16",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 381,
+    "numero_processo": "10201267420258260100",
+    "nome_reu": "TOS",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 280.859,96",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 50,
+    "numero_processo": "10410888920238260100",
+    "nome_reu": "MARIA NARA REGIS DIOGENES",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 279.853,69",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 621,
+    "numero_processo": "10175285020258260100",
+    "nome_reu": ": HAYET MAHMOUDI",
+    "cpf_cnpj_reu": "24474976878",
+    "valor_causa": "R$ 277.814,28",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 820,
+    "numero_processo": "10199040920258260100",
+    "nome_reu": "GEORGIOS KONSTANTINOS KATAVATIS",
+    "cpf_cnpj_reu": "03403638863",
+    "valor_causa": "R$ 277.297,97",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 16,
+    "numero_processo": "11617825320248260100",
+    "nome_reu": "SHOP'S PASTEL LTDA. - M.E.",
+    "cpf_cnpj_reu": "53942827000180",
+    "valor_causa": "R$ 277.172,68",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 230,
+    "numero_processo": "10334356520258260100",
+    "nome_reu": "SERGIO RICARDO FERREIRA",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 277.137,03",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 372,
+    "numero_processo": "10496727720258260100",
+    "nome_reu": "TOS",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 276.935,21",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 641,
+    "numero_processo": "10927699820238260100",
+    "nome_reu": "RELAX LOUNGE COMERCIO DE TABACARIA ATACADISTA EIRELI",
+    "cpf_cnpj_reu": "23408497000187",
+    "valor_causa": "R$ 274.938,81",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 158,
+    "numero_processo": "10767248220248260100",
+    "nome_reu": "LUIS HENRIQUE PIVA",
+    "cpf_cnpj_reu": "25173303875",
+    "valor_causa": "R$ 273.862,66",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 595,
+    "numero_processo": "10656844020238260100",
+    "nome_reu": "JOSE DE SOUZA NUNES",
+    "cpf_cnpj_reu": "09172539305",
+    "valor_causa": "R$ 272.668,06",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 831,
+    "numero_processo": "11724967220248260100",
+    "nome_reu": "PAULO ROBERTO DO NASCIMENTO",
+    "cpf_cnpj_reu": "47222875549",
+    "valor_causa": "R$ 272.400,00",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 134,
+    "numero_processo": "10838262420258260100",
+    "nome_reu": "ARNALDO BALDINI",
+    "cpf_cnpj_reu": "57602603834",
+    "valor_causa": "R$ 271.729,83",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 869,
+    "numero_processo": "10541778220238260100",
+    "nome_reu": "CREDORES COM PEDIDO DE TUTELA DE URGÊNCIA CONTRA: 1) NELSON LUIZ RIBEIRO VIEIRA",
+    "cpf_cnpj_reu": "30251583872",
+    "valor_causa": "R$ 271.529,02",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 647,
+    "numero_processo": "10435467920238260100",
+    "nome_reu": "VILA NOVA AGUAS MINEIRAIS LTDA",
+    "cpf_cnpj_reu": "46557203000184",
+    "valor_causa": "R$ 271.306,07",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 277,
+    "numero_processo": "11199700220228260100",
+    "nome_reu": "CLARICE KASSAWARA",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 270.929,62",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 462,
+    "numero_processo": "10791735020238260002",
+    "nome_reu": "VICTOR KOLOSZUK",
+    "cpf_cnpj_reu": "42228123820",
+    "valor_causa": "R$ 268.607,33",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 675,
+    "numero_processo": "10091122920248260068",
+    "nome_reu": "BANCO BRADESCO S.A.",
+    "cpf_cnpj_reu": "60746948000112",
+    "valor_causa": "R$ 268.486,57",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 350,
+    "numero_processo": "10024074220238260038",
+    "nome_reu": "RAFAEL LOPES FRAGOSO",
+    "cpf_cnpj_reu": "33783863805",
+    "valor_causa": "R$ 267.091,66",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 749,
+    "numero_processo": "10190326120238260068",
+    "nome_reu": "DANILO BEZERRA ARAUJO",
+    "cpf_cnpj_reu": "28737667866",
+    "valor_causa": "R$ 266.500,66",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 756,
+    "numero_processo": "10048768520238260127",
+    "nome_reu": "ELAINE HONORIO DOS SANTOS",
+    "cpf_cnpj_reu": "14517756874",
+    "valor_causa": "R$ 265.738,64",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 141,
+    "numero_processo": "10170252920258260100",
+    "nome_reu": "CLEUSA PLACCO TAURISANO",
+    "cpf_cnpj_reu": "40270122753",
+    "valor_causa": "R$ 265.490,20",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 353,
+    "numero_processo": "10043454620238260079",
+    "nome_reu": "TO N. RPM/4046287  CONTA N. 61537  AGÊNCIA N. 201 PARA CONFERIR O ORIGINAL",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 264.344,75",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 800,
+    "numero_processo": "10619389620258260100",
+    "nome_reu": "GEORGIOS KONSTANTINOS KATAVATIS",
+    "cpf_cnpj_reu": "03403638863",
+    "valor_causa": "R$ 264.147,89",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 603,
+    "numero_processo": "11435315520228260100",
+    "nome_reu": "PEDRO HENRIQUE DA SILVA GONÇALVES DA TRINDADE",
+    "cpf_cnpj_reu": "41530380839",
+    "valor_causa": "R$ 264.129,50",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 5,
+    "numero_processo": "11140420220248260100",
+    "nome_reu": "WALLACE DE OLIVEIRA GUIRELLI",
+    "cpf_cnpj_reu": "02723344800",
+    "valor_causa": "R$ 263.860,99",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 824,
+    "numero_processo": "10150584620258260100",
+    "nome_reu": "WANDERLAN DANTAS ABRANTES",
+    "cpf_cnpj_reu": "56865236491",
+    "valor_causa": "R$ 262.853,33",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 310,
+    "numero_processo": "10674246220258260100",
+    "nome_reu": ": RX MATERIAIS ELETRICOS E DE CONSTRUCAO LTDA",
+    "cpf_cnpj_reu": "47608257000194",
+    "valor_causa": "R$ 260.711,30",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 504,
+    "numero_processo": "10093355720258260161",
+    "nome_reu": "Não encontrado",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 258.532,65",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 843,
+    "numero_processo": "10693519720248260100",
+    "nome_reu": "1) JOSE ROBERTO ESTEVANATO",
+    "cpf_cnpj_reu": "33524713000103",
+    "valor_causa": "R$ 258.364,17",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 668,
+    "numero_processo": "10288196720138260100",
+    "nome_reu": "Não encontrado",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 257.502,26",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 886,
+    "numero_processo": "10090964720228260100",
+    "nome_reu": "PARTIDA OBRIGOU-SE À QUITAÇÃO MENSAL E TEMPESTIVA DE TODAS AS DESPESAS E ACESSÓRIOS CONTRATUAIS NO VENCIMENTO ACORDADO CONFORME DOCUMENTOS TRAZIDOS AOS AUTOS. II. DESCUMPRIMENTO E VENCIMENTO ANTECIPADO DO CONTRATO 2. EMBORA A PRESTAÇÃO DE SERVIÇOS FINANCE",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 256.642,19",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 748,
+    "numero_processo": "10047611320248260068",
+    "nome_reu": "RENAN MORENO",
+    "cpf_cnpj_reu": "36927572805",
+    "valor_causa": "R$ 255.866,85",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 116,
+    "numero_processo": "10042363220248260100",
+    "nome_reu": "ALEX LIMA DOS SANTOS",
+    "cpf_cnpj_reu": "42807518000181",
+    "valor_causa": "R$ 255.801,02",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 157,
+    "numero_processo": "10935716220248260100",
+    "nome_reu": "CSS PEÇAS E PNEUS LTDA",
+    "cpf_cnpj_reu": "45341961000106",
+    "valor_causa": "R$ 254.677,53",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 411,
+    "numero_processo": "11331712720238260100",
+    "nome_reu": "PRISCILA REIS DA SILVA",
+    "cpf_cnpj_reu": "34433362808",
+    "valor_causa": "R$ 253.387,18",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 685,
+    "numero_processo": "10622866620158260100",
+    "nome_reu": "LUIZ CARLOS PARDO",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 252.495,89",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 872,
+    "numero_processo": "10504311220238260100",
+    "nome_reu": "UM DETERMINADO PATRIMÔNIO; NEM SE DEVE AMPARAR A CONDUTA DESONESTA DE QUEM INTENCIONALMENTE DISPÕE DE SEUS BENS COM EVIDENTE PROPÓSITO DE FRAUDAR FUTURAS RESPONSABILIDADES. HÁ PRECEDENTES NA JURISPRUDÊNCIA BRASILEIRA QUE ACOLHEM A TESE EXPOSTA. (THEODORO ",
+    "cpf_cnpj_reu": "Não encontrado",
+    "valor_causa": "R$ 252.153,80",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 44,
+    "numero_processo": "10691694820238260100",
+    "nome_reu": "RELAX LOUNGE COMÉRCIO DE TABACARIA ATACADISTA EIRELI",
+    "cpf_cnpj_reu": "23408497000187",
+    "valor_causa": "R$ 248.383,78",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 587,
+    "numero_processo": "11216031420238260100",
+    "nome_reu": "SENDY DA SILVA GUIMARAES",
+    "cpf_cnpj_reu": "32664610880",
+    "valor_causa": "R$ 245.990,18",
+    "status": "PENDENTE"
+  },
+  {
+    "id": 10,
+    "numero_processo": "10048466320258260100",
+    "nome_reu": "LAERTE PAIVA LEITE",
+    "cpf_cnpj_reu": "11061734498",
+    "valor_causa": "R$ 245.287,25",
+    "status": "PENDENTE"
+  }
+]


### PR DESCRIPTION
## Summary
- add Laravel controllers, routes, and configuration to manage authentication and expose the processos dataset
- migrate the login and dashboard markup into Blade views backed by shared layout metadata
- move front-end assets into the Laravel public directory, updating the JavaScript to consume the new /processos endpoint and submit server-side logout requests

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4748f14bc832b952d8b98d1613051